### PR TITLE
Fix issue getting commit date for annotated tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2024-04-01
+
+### Fixed
+- Update git command to get commit time to support annotated tags
+
 ## [0.4.2] - 2024-03-26
 
 ### Changed

--- a/utils.go
+++ b/utils.go
@@ -35,7 +35,7 @@ func getGoInfoFromGit(ctx context.Context, version string) ([]byte, string, erro
 		return nil, "", fmt.Errorf("Current directory is not in a Git repository: %w", err)
 	}
 
-	gitCommitTime, err := exec.CommandContext(ctx, "git", "show", "--no-patch", "--format=%ct", version).Output()
+	gitCommitTime, err := exec.CommandContext(ctx, "git", "log", "--max-count=1", "--format=%ct", version).Output()
 	if err != nil {
 		return nil, "", fmt.Errorf("Git revision not found: %s: %w", version, err)
 	}


### PR DESCRIPTION
Use git command to get commit date that has the same output for annotated tags